### PR TITLE
fix: mismatch superProperties type

### DIFF
--- a/ios/Plugin/MixpanelPlugin.swift
+++ b/ios/Plugin/MixpanelPlugin.swift
@@ -14,14 +14,15 @@ public class MixpanelPlugin: CAPPlugin {
         let optOutTrackingByDefault = getConfig().getBoolean("optOutTrackingByDefault", false)
         let trackAutomaticEvents = getConfig().getBoolean("trackAutomaticEvents", true)
         let disableIpCollection = getConfig().getBoolean("disableIosIpCollection", false)
-        let superProperties = getConfig().getObject("superProperties") ?? [:]
+        let rawSuperProps = getConfig().getObject("superProperties") ?? [:]
+        let superProperties = rawSuperProps.compactMapValues { $0 as? MixpanelType }
 
         let instance = Mixpanel.initialize(
             token: token,
             trackAutomaticEvents: trackAutomaticEvents,
             optOutTrackingByDefault: optOutTrackingByDefault,
-            serverURL: serverURL,
-            superProperties: superProperties
+            superProperties: superProperties,
+            serverURL: serverURL
         )
         instance.useIPAddressForGeoLocation = !disableIpCollection
     }


### PR DESCRIPTION
Hello,

Thanks for updating this plugin. I encounter an issue with XCode 16.4 when trying to build the app:
```Cannot convert value of type 'JSObject' ('aka Dictionary<String, any JSValue>') to expected argument type 'Properties' (aka 'Dictionary<String, any MixpanelType>')```

This PR should solve the issue.